### PR TITLE
W4458281680 - update event import unit mapping to use calendar IDs first

### DIFF
--- a/modules/du_event_import/src/EventImport.php
+++ b/modules/du_event_import/src/EventImport.php
@@ -273,26 +273,85 @@ class EventImport {
     $primaryOrg = '';
     $additional_orgs = [];
     $orgs = [];
-    if (!empty($event['primaryOrg'][0]['organizationID'])) {
-      $orgs[] = $event['primaryOrg'][0]['organizationID'];
-      $primaryOrg = $event['primaryOrg'][0]['organizationName'];
+    $calendar_ids = [];
+
+    /**
+     * Use calendars from the API response first.
+     *
+     * Example API response:
+     * "calendars": [
+     *   "187",
+     *   "1858"
+     * ]
+     *
+     */
+    if (!empty($event['calendars']) && is_array($event['calendars'])) {
+      $calendar_ids = array_filter(array_map('trim', $event['calendars']));
     }
-    if (!empty($event['secondaryOrgs'])) {
+
+    /**
+     * Preserve primaryOrg for display/fallback purposes.
+     *
+     * Direct Import response may return primaryOrg as an object:
+     * "primaryOrg": {
+     *   "organizationID": 187,
+     *   "organizationName": "Lamont School of Music"
+     * }
+     */
+    if (!empty($event['primaryOrg']['organizationID'])) {
+      $orgs[] = (string) $event['primaryOrg']['organizationID'];
+      $primaryOrg = $event['primaryOrg']['organizationName'] ?? '';
+    }
+
+    /**
+     * Backward compatibility:
+     * Some older payloads may return primaryOrg as an array.
+     */
+    elseif (!empty($event['primaryOrg'][0]['organizationID'])) {
+      $orgs[] = (string) $event['primaryOrg'][0]['organizationID'];
+      $primaryOrg = $event['primaryOrg'][0]['organizationName'] ?? '';
+    }
+
+    /**
+     * Preserve secondaryOrgs for display/fallback purposes.
+     */
+    if (!empty($event['secondaryOrgs']) && is_array($event['secondaryOrgs'])) {
       foreach ($event['secondaryOrgs'] as $org) {
-        $orgs[] = $org['organizationID'];
-        $additional_orgs[] = ['value' => $org['organizationName']];
+        if (!empty($org['organizationID'])) {
+          $orgs[] = (string) $org['organizationID'];
+        }
+
+        if (!empty($org['organizationName'])) {
+          $additional_orgs[] = ['value' => $org['organizationName']];
+        }
       }
     }
 
-    // Match up org IDs with the unit taxonomy term if the IDs exist.
     $unit_ids = [];
-    if (!empty($orgs)) {
-    $unit_ids = \Drupal::entityQuery('taxonomy_term')
-      ->accessCheck(TRUE)
-      ->condition('vid', 'unit')
-      ->condition('field_25_live_id', $orgs, 'IN')
-      ->execute();
-    };
+
+    /**
+     * PRIMARY PATH:
+     * Match Unit taxonomy terms using calendar/category IDs.
+     */
+    if (!empty($calendar_ids)) {
+      $unit_ids = \Drupal::entityQuery('taxonomy_term')
+        ->accessCheck(TRUE)
+        ->condition('vid', 'unit')
+        ->condition('field_25_live_id', $calendar_ids, 'IN')
+        ->execute();
+    }
+
+    /**
+     * FALLBACK PATH:
+     * If no Unit terms were found from calendars, use the old Organization ID logic.
+     */
+    if (empty($unit_ids) && !empty($orgs)) {
+      $unit_ids = \Drupal::entityQuery('taxonomy_term')
+        ->accessCheck(TRUE)
+        ->condition('vid', 'unit')
+        ->condition('field_25_live_id', $orgs, 'IN')
+        ->execute();
+    }
 
     $description = '';
     if (!empty($event['description'])) {

--- a/modules/du_event_import/src/EventImport.php
+++ b/modules/du_event_import/src/EventImport.php
@@ -275,7 +275,7 @@ class EventImport {
     $orgs = [];
     $calendar_ids = [];
 
-    /**
+    /*
      * Use calendars from the API response first.
      *
      * Example API response:
@@ -283,13 +283,12 @@ class EventImport {
      *   "187",
      *   "1858"
      * ]
-     *
      */
     if (!empty($event['calendars']) && is_array($event['calendars'])) {
       $calendar_ids = array_filter(array_map('trim', $event['calendars']));
     }
 
-    /**
+    /*
      * Preserve primaryOrg for display/fallback purposes.
      *
      * Direct Import response may return primaryOrg as an object:
@@ -303,7 +302,7 @@ class EventImport {
       $primaryOrg = $event['primaryOrg']['organizationName'] ?? '';
     }
 
-    /**
+    /*
      * Backward compatibility:
      * Some older payloads may return primaryOrg as an array.
      */
@@ -312,7 +311,7 @@ class EventImport {
       $primaryOrg = $event['primaryOrg'][0]['organizationName'] ?? '';
     }
 
-    /**
+    /*
      * Preserve secondaryOrgs for display/fallback purposes.
      */
     if (!empty($event['secondaryOrgs']) && is_array($event['secondaryOrgs'])) {


### PR DESCRIPTION
fix: prioritize calendar IDs for event unit mapping

Updated EventImport.php so Direct Import uses the calendars array
from the API response as the primary source for Drupal Unit assignment.

The import now maps calendar/category IDs to Unit taxonomy terms through
field_25_live_id before falling back to the existing primaryOrg and
secondaryOrgs organization ID logic.

Also added support for primaryOrg being returned as an object while
preserving compatibility with the older array-based response format.